### PR TITLE
Enabling optional selection of a region of interest in the camera feed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ find_package(Threads REQUIRED)
 # LibTorch (PyTorch C++ API)
 find_package(Torch REQUIRED)
 # Qt6 Widgets for GUI
-find_package(Qt6 COMPONENTS Widgets REQUIRED)
+find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets)
 
 # ============================================================================
 # Qt Configuration
@@ -101,11 +101,11 @@ set(CMAKE_AUTORCC OFF)
 
 # Project source directory
 include_directories("${CMAKE_SOURCE_DIR}/src")
+
 # Third-party includes
 include_directories(
   ${OpenCV_INCLUDE_DIRS}
   ${TORCH_INCLUDE_DIRS}
-  ${Qt6Widgets_INCLUDE_DIRS}
 )
 
 # ============================================================================
@@ -139,11 +139,13 @@ set_target_properties(gravy_lens PROPERTIES
 # Linker settings
 
 target_link_libraries(gravy_lens PRIVATE
+  Qt6::Core
+  Qt6::Gui       
+  Qt6::Widgets
   ${OpenCV_LIBS}
   Threads::Threads
   ${FFTW3_LIBRARIES}
   ${TORCH_LIBRARIES}
-  Qt6::Widgets
 )
 
 if(APPLE)

--- a/README.md
+++ b/README.md
@@ -205,6 +205,11 @@ Options:
   --di, --distortInside                              Distort inside the mask?
   --flip                                             Flip the camera feed
                                                      horizontally?
+  --roi, --selectROI                                 Select a region of
+                                                     interest (ROI) in the
+                                                     camera feed to apply the
+                                                     lensing effect. If not set,
+                                                     the full frame is used.
 ```
 
 - Place background images (up to 10) in the `backgrounds/` directory.

--- a/README.md
+++ b/README.md
@@ -71,26 +71,26 @@ For libtorch, see their [installation instructions](https://pytorch.org/). You w
 
 ## Build with CMake
 
-   To build the release build:
+To build the release build:
 
-   ```bash
-   cmake -B build \
-     -DCMAKE_PREFIX_PATH=/path/to/libtorch/ \
-     -DCMAKE_BUILD_TYPE=Release
-   cmake --build build --config Release -- -j$(nproc)
-   ```
+```bash
+cmake -B build \
+  -DCMAKE_PREFIX_PATH=/path/to/libtorch/ \
+  -DCMAKE_BUILD_TYPE=Release
+cmake --build build --config Release -- -j$(nproc)
+```
 
-   Note that you may need to point directly to FFTW if it is installed in a nonstandard location:
+Note that you may need to point directly to FFTW if it is installed in a nonstandard location:
 
-   ```bash
-   cmake -B build \
-     -DFFTW3_ROOT=/path/to/fftw3 \
-     -DCMAKE_PREFIX_PATH=/path/to/libtorch/ \
-     -DCMAKE_BUILD_TYPE=Release
-   cmake --build build --config Release -- -j$(nproc)
-   ```
+```bash
+cmake -B build \
+  -DFFTW3_ROOT=/path/to/fftw3 \
+  -DCMAKE_PREFIX_PATH=/path/to/libtorch/ \
+  -DCMAKE_BUILD_TYPE=Release
+cmake --build build --config Release -- -j$(nproc)
+```
 
-   The executable `gravy_lens` will then be placed in the project root.
+The executable `gravy_lens` will then be placed in the project root.
 
 ## Generating Segementation models
 
@@ -154,15 +154,57 @@ python get_models.py \
 ## Usage
 
 ```bash
-./gravy_lens \
-  --nthreads <int>       # number of FFTW threads (≥2)
-  [--strength <float>]    # lens strength factor (default 0.1)
-  [--softening <float>]   # softening radius (default 30.0)
-  [--maskScale <int>]     # segmentation downscale factor (default 4)
-  [--deviceIndex <int>]   # Torch device index (default 0)
-  [--padFactor <int>]     # FFT padding factor (default 2)
-  [--modelPath <string>]  # path to segmentation .pt model
-  [--debugGrid]           # show mask & camera feed grid
+Usage: ./gravy_lens [options]
+GravyLensing applies a gravitational lensing effect to images based on people detected in a camera feed.
+
+Options:
+  -h, --help                                         Displays help on
+                                                     commandline options.
+  --help-all                                         Displays help, including
+                                                     generic Qt options.
+  -n, --nthreads <nthreads>                          Number of CPU threads used
+                                                     in the calculation (must be
+                                                     >= 2).
+  -s, --strength <strength>                          Strength factor for the
+                                                     lensing effect (float,
+                                                     default=0.1).
+  -f, --softening <softening>                        Softening radius in pixels
+                                                     applied to the lensing
+                                                     effect (float,
+                                                     default=30.0).
+  -m, --modelSize <modelSize>                        Segmentation model size,
+                                                     bigger means more accurate
+                                                     people but at the expense
+                                                     of frame rate (int,
+                                                     default=512).
+  -d, --deviceIndex <deviceIndex>                    Device index, i.e. which
+                                                     camera to use (int,
+                                                     default=0).
+  -g, --debugGrid                                    Show a debugging grid with
+                                                     the camera feed, mask, and
+                                                     lensed image.
+  -p, --padFactor <padFactor>                        Padding factor for FFT
+                                                     (int, default=2).
+  --mp, --modelPath <modelPath>                      Path to the segmentation
+                                                     model (string).
+  -t, --temporalSmooth <temporalSmooth>              Temporal frame smoothing
+                                                     factor, i.e. how much of
+                                                     previous frames is used to
+                                                     smooth out temporal
+                                                     flucations in the person
+                                                     detection mask (float,
+                                                     default=0.25).
+  --lr, --lowerRes <lowerRes>                        Lower resolution factor
+                                                     for the lensing effect
+                                                     (float, default=1.0).
+  --sb, --secondsPerBackground <secondsPerBackground Seconds per background
+  >                                                  image, if -1 then
+                                                     background images are
+                                                     selected through the 0-9
+                                                     keys (int, default=-1).
+  --di, --distortInside                              Distort inside the mask?
+  --flip                                             Flip the camera feed
+                                                     horizontally?
 ```
 
 - Place background images (up to 10) in the `backgrounds/` directory.

--- a/src/cam_feed.cpp
+++ b/src/cam_feed.cpp
@@ -34,6 +34,66 @@
 #include "cam_feed.hpp"
 
 /**
+ * @brief Display an interactive ROI selector and build a mask.
+ *
+ * This static helper opens a window to let the user draw a rectangular ROI
+ * on the provided frame. If the user cancels, the full frame is used.
+ * It returns both the selected rectangle and a binary mask of the same size.
+ *
+ * @param frame The image on which to select the ROI (modified for preview).
+ * @return A pair consisting of the selected cv::Rect and its binary mask as
+ * cv::Mat.
+ */
+static std::pair<cv::Rect, cv::Mat> selectROIAndMask(cv::Mat &frame) {
+  // Mirror preview
+  // cv::flip(frame, frame, 1);
+
+  // Show selector
+  cv::namedWindow("Select ROI", cv::WINDOW_AUTOSIZE);
+  cv::Rect sel = cv::selectROI("Select ROI", frame);
+  cv::destroyWindow("Select ROI");
+
+  // Record the selection and store the mask
+  cv::Rect rect;
+  cv::Mat mask;
+  if (sel.width > 0 && sel.height > 0) {
+    rect = sel;
+    mask = cv::Mat::zeros(frame.size(), CV_8UC1);
+    cv::rectangle(mask, sel, cv::Scalar(255), cv::FILLED);
+  } else {
+    // Full-frame fallback
+    rect = cv::Rect(0, 0, frame.cols, frame.rows);
+    mask = cv::Mat(frame.size(), CV_8UC1, cv::Scalar(255));
+  }
+
+  // Return the selected rectangle and mask
+  return {rect, mask};
+}
+
+/**
+ * @brief Crop an image to the given ROI and apply mask.
+ *
+ * Extracts the rectangular region defined by roiRect from src,
+ * zeroing out any pixels outside the binary mask within that region.
+ * The returned image has dimensions roiRect.size().
+ *
+ * @param src The source image (multi-channel).
+ * @param mask The full-frame binary mask; non-zero pixels define valid ROI.
+ * @param roiRect The rectangle to crop from src and mask.
+ * @return A new cv::Mat of size roiRect.size() containing only the ROI.
+ */
+static cv::Mat applyROIMaskAndCrop(const cv::Mat &src, const cv::Mat &mask,
+                                   const cv::Rect &roiRect) {
+  // Crop both source and mask to the rectangle
+  cv::Mat srcCrop = src(roiRect);
+  cv::Mat maskCrop = mask(roiRect);
+  // Allocate output and apply mask
+  cv::Mat output = cv::Mat::zeros(srcCrop.size(), srcCrop.type());
+  srcCrop.copyTo(output, maskCrop);
+  return output;
+}
+
+/**
  * @brief Constructor for the CameraFeed class.
  *
  * This constructor initializes the camera feed with the specified device index,
@@ -59,6 +119,24 @@ CameraFeed::CameraFeed(int deviceIndex) : deviceIndex_(deviceIndex) {
             << "\n";
   std::cout << "[CameraFeed] Camera backend: " << cap_.get(cv::CAP_PROP_BACKEND)
             << "\n";
+
+  // Grab frame for ROI selection
+  cv::Mat firstFrame;
+  if (!cap_.read(firstFrame) || firstFrame.empty()) {
+    emit captureError("Failed to grab initial frame for ROI selection");
+    return;
+  }
+
+  // Delegate to static helper
+  std::tie(roiRect_, roiMask_) = selectROIAndMask(firstFrame);
+
+  std::cout << "[CameraFeed] ROI: (x, y)=(" << roiRect_.x << ", " << roiRect_.y
+            << ") " << "widthxheight=" << roiRect_.width << "x"
+            << roiRect_.height << "\n";
+
+  // Report some info about the ROI mask
+  std::cout << "[CameraFeed] ROI mask size: " << roiMask_.size()
+            << ", type: " << roiMask_.type() << "\n";
 }
 
 /**
@@ -103,6 +181,8 @@ void CameraFeed::startCaptureLoop() {
 
   // Define a local reusable header for the frame
   cv::Mat frame;
+  cv::Mat flipped;
+  cv::Mat masked;
 
   // Loop until the end of time (or until the thread is stopped)
   while (QThread::currentThread()->isRunning() &&
@@ -111,13 +191,17 @@ void CameraFeed::startCaptureLoop() {
     // Capture a frame from the camera
     if (!cap_.grab() || !cap_.retrieve(frame)) {
       emit captureError("Frame capture failed");
+      std::cout << "[CameraFeed] Frame capture failed\n";
       break;
     }
 
     // Flip the frame horizontally to ensure the correct orientation
-    cv::flip(frame, frame, /*flipCode=*/1);
+    // cv::flip(frame, flipped, 1);
+
+    // Apply ROI mask and crop to ROI
+    masked = applyROIMaskAndCrop(frame, roiMask_, roiRect_);
 
     // Emit the captured frame
-    emit frameCaptured(frame);
+    emit frameCaptured(masked);
   }
 }

--- a/src/cam_feed.hpp
+++ b/src/cam_feed.hpp
@@ -39,7 +39,7 @@ class CameraFeed : public QObject {
   Q_OBJECT
 
 public:
-  CameraFeed(int deviceIndex = 0, bool flip = false);
+  CameraFeed(int deviceIndex = 0, bool flip = false, bool selectROI = false);
   ~CameraFeed();
 
   /// Start continuous capture in this thread
@@ -67,4 +67,7 @@ private:
 
   // Are we flipping the camera feed horizontally?
   bool flip_ = false;
+
+  // Are we doing ROI selection?
+  bool doingROI_ = false;
 };

--- a/src/cam_feed.hpp
+++ b/src/cam_feed.hpp
@@ -53,10 +53,15 @@ signals:
   void captureError(const QString &msg);
 
 private:
-  std::atomic<bool> running_{false};
+  bool initCamera(); ///< Called by ctor to open cap_
 
-  bool initCamera(); // called from ctor
-
+  // The device index for the camera (0 for default camera)
   int deviceIndex_;
+
+  // OpenCV video capture object
   cv::VideoCapture cap_;
+
+  // ROI selection and mask
+  cv::Rect roiRect_;
+  cv::Mat roiMask_;
 };

--- a/src/cam_feed.hpp
+++ b/src/cam_feed.hpp
@@ -39,7 +39,7 @@ class CameraFeed : public QObject {
   Q_OBJECT
 
 public:
-  CameraFeed(int deviceIndex = 0);
+  CameraFeed(int deviceIndex = 0, bool flip = false);
   ~CameraFeed();
 
   /// Start continuous capture in this thread
@@ -64,4 +64,7 @@ private:
   // ROI selection and mask
   cv::Rect roiRect_;
   cv::Mat roiMask_;
+
+  // Are we flipping the camera feed horizontally?
+  bool flip_ = false;
 };

--- a/src/cmd_parser.hpp
+++ b/src/cmd_parser.hpp
@@ -48,6 +48,7 @@ public:
   int secondsPerBackground;
   bool distortInside;
   bool flip;
+  bool selectROI;
   std::string modelPath;
 
   // Constructor is also the parser
@@ -148,6 +149,13 @@ public:
                                   "Flip the camera feed horizontally?");
     parser.addOption(flipOption);
 
+    // selectROI <bool> (flag only; no argument)
+    QCommandLineOption selectROIOption(
+        QStringList() << "roi" << "selectROI",
+        "Select a region of interest (ROI) in the camera feed to apply the "
+        "lensing effect. If not set, the full frame is used.");
+    parser.addOption(selectROIOption);
+
     parser.process(app);
 
     // Validate required --nthreads
@@ -223,6 +231,7 @@ public:
 
     opts.distortInside = parser.isSet(distortInsideOption);
     opts.flip = parser.isSet(flipOption);
+    opts.selectROI = parser.isSet(selectROIOption);
 
     return opts;
   }

--- a/src/cmd_parser.hpp
+++ b/src/cmd_parser.hpp
@@ -53,37 +53,46 @@ public:
   // Constructor is also the parser
   static CommandLineOptions parse(QApplication &app) {
     QCommandLineParser parser;
-    parser.setApplicationDescription("Your App Description");
+    parser.setApplicationDescription(
+        "GravyLensing applies a gravitational lensing effect to images based "
+        "on people detected in a camera feed.");
     parser.addHelpOption();
 
     // --nthreads <int> (required)
-    QCommandLineOption nthreadsOption(QStringList() << "n" << "nthreads",
-                                      "Number of threads (must be >= 2).",
-                                      "nthreads");
+    QCommandLineOption nthreadsOption(
+        QStringList() << "n" << "nthreads",
+        "Number of CPU threads used in the calculation (must be >= 2).",
+        "nthreads");
     parser.addOption(nthreadsOption);
 
     // --strength <float> (default 0.1)
-    QCommandLineOption strengthOption(QStringList() << "s" << "strength",
-                                      "Strength factor (float).", "strength",
-                                      "0.1");
+    QCommandLineOption strengthOption(
+        QStringList() << "s" << "strength",
+        "Strength factor for the lensing effect (float, default=0.1).",
+        "strength", "0.1");
     parser.addOption(strengthOption);
 
     // --softening <float> (default 30.0)
-    QCommandLineOption softeningOption(QStringList() << "f" << "softening",
-                                       "Softening radius (float).", "softening",
-                                       "30.0");
+    QCommandLineOption softeningOption(
+        QStringList() << "f" << "softening",
+        "Softening radius in pixels applied to the lensing effect (float, "
+        "default=30.0).",
+        "softening", "30.0");
     parser.addOption(softeningOption);
 
     // --modelSize <int> (default 512)
-    QCommandLineOption modelSizeOption(QStringList() << "m" << "modelSize",
-                                       "Segmentation model size (int).",
-                                       "modelSize", "512");
+    QCommandLineOption modelSizeOption(
+        QStringList() << "m" << "modelSize",
+        "Segmentation model size, bigger means more accurate people but at the "
+        "expense of frame rate (int, default=512).",
+        "modelSize", "512");
     parser.addOption(modelSizeOption);
 
     // --device-index <int> (default 0)
-    QCommandLineOption deviceIndexOption(QStringList() << "d" << "deviceIndex",
-                                         "Device index (int).", "deviceIndex",
-                                         "0");
+    QCommandLineOption deviceIndexOption(
+        QStringList() << "d" << "deviceIndex",
+        "Device index, i.e. which camera to use (int, default=0).",
+        "deviceIndex", "0");
     parser.addOption(deviceIndexOption);
 
     // --debug-grid  (flag only; no argument)
@@ -93,9 +102,9 @@ public:
     parser.addOption(debugGridOption);
 
     // --pad-factor <int> (default 2)
-    QCommandLineOption padFactorOption(QStringList() << "p" << "padFactor",
-                                       "Padding factor for FFT (int).",
-                                       "padFactor", "2");
+    QCommandLineOption padFactorOption(
+        QStringList() << "p" << "padFactor",
+        "Padding factor for FFT (int, default=2).", "padFactor", "2");
     parser.addOption(padFactorOption);
 
     // --model-path <string> (default "models/deeplabv3_mobilenet_v3_large.pt")
@@ -108,30 +117,35 @@ public:
     // --temporal smooth <float> (default 0.6)
     QCommandLineOption temporalSmoothOption(
         QStringList() << "t" << "temporalSmooth",
-        "Temporal frame smoothing factor (float).", "temporalSmooth", "0.25");
+        "Temporal frame smoothing factor, i.e. how much of previous frames is "
+        "used to smooth out temporal flucations in the person detection mask "
+        "(float, default=0.25).",
+        "temporalSmooth", "0.25");
     parser.addOption(temporalSmoothOption);
 
     // lowerRes <float> (default 1.0)
     QCommandLineOption lowerResOption(
         QStringList() << "lr" << "lowerRes",
-        "Lower resolution factor for the lensing effect (float).", "lowerRes",
-        "1.0");
+        "Lower resolution factor for the lensing effect (float, default=1.0).",
+        "lowerRes", "1.0");
     parser.addOption(lowerResOption);
 
     // secondsPerBackground <int> (default -1, i.e infinite)
     QCommandLineOption secondsPerBackgroundOption(
         QStringList() << "sb" << "secondsPerBackground",
-        "Seconds per background (int).", "secondsPerBackground", "-1");
+        "Seconds per background image, if -1 then background images are "
+        "selected through the 0-9 keys (int, default=-1).",
+        "secondsPerBackground", "-1");
     parser.addOption(secondsPerBackgroundOption);
 
     // distortInside <bool> (flag only; no argument)
     QCommandLineOption distortInsideOption(
-        QStringList() << "di" << "distortInside", "Distort inside the mask.");
+        QStringList() << "di" << "distortInside", "Distort inside the mask?");
     parser.addOption(distortInsideOption);
 
     // flip <bool> (flag only; no argument)
     QCommandLineOption flipOption(QStringList() << "flip",
-                                  "Flip the camera feed horizontally.");
+                                  "Flip the camera feed horizontally?");
     parser.addOption(flipOption);
 
     parser.process(app);

--- a/src/cmd_parser.hpp
+++ b/src/cmd_parser.hpp
@@ -47,6 +47,7 @@ public:
   float lowerRes;
   int secondsPerBackground;
   bool distortInside;
+  bool flip;
   std::string modelPath;
 
   // Constructor is also the parser
@@ -128,6 +129,11 @@ public:
         QStringList() << "di" << "distortInside", "Distort inside the mask.");
     parser.addOption(distortInsideOption);
 
+    // flip <bool> (flag only; no argument)
+    QCommandLineOption flipOption(QStringList() << "flip",
+                                  "Flip the camera feed horizontally.");
+    parser.addOption(flipOption);
+
     parser.process(app);
 
     // Validate required --nthreads
@@ -202,6 +208,7 @@ public:
     }
 
     opts.distortInside = parser.isSet(distortInsideOption);
+    opts.flip = parser.isSet(flipOption);
 
     return opts;
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -137,6 +137,7 @@ int main(int argc, char **argv) {
   float lowerRes = opts.lowerRes;
   int secondsPerBackground = opts.secondsPerBackground;
   bool distortInside = opts.distortInside;
+  bool flip = opts.flip;
   const std::string modelPath = opts.modelPath;
 
   // Correct the number of threads to account for those that have
@@ -156,7 +157,7 @@ int main(int argc, char **argv) {
   // Create workers & threads
 
   // Camera feed
-  CameraFeed *camFeed = new CameraFeed(deviceIndex);
+  CameraFeed *camFeed = new CameraFeed(deviceIndex, flip);
   QThread *camThread = new QThread;
   camFeed->moveToThread(camThread);
   QObject::connect(camThread, &QThread::started, camFeed,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -138,6 +138,7 @@ int main(int argc, char **argv) {
   int secondsPerBackground = opts.secondsPerBackground;
   bool distortInside = opts.distortInside;
   bool flip = opts.flip;
+  bool selectROI = opts.selectROI;
   const std::string modelPath = opts.modelPath;
 
   // Correct the number of threads to account for those that have
@@ -157,7 +158,7 @@ int main(int argc, char **argv) {
   // Create workers & threads
 
   // Camera feed
-  CameraFeed *camFeed = new CameraFeed(deviceIndex, flip);
+  CameraFeed *camFeed = new CameraFeed(deviceIndex, flip, selectROI);
   QThread *camThread = new QThread;
   camFeed->moveToThread(camThread);
   QObject::connect(camThread, &QThread::started, camFeed,


### PR DESCRIPTION
Now you can pass `--selectROI` as an argument and select a subregion of the image to detect people in. This is useful for when the background is going to be in the camera feed and you want a direct mapping.